### PR TITLE
Fix django 1.10 depreciation warnings

### DIFF
--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from jet.dashboard import modules
 from jet.dashboard.models import UserDashboardModule
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 from django.utils.translation import ugettext_lazy as _
 from jet.ordered_set import OrderedSet
 from jet.utils import get_admin_site_name

--- a/jet/dashboard/urls.py
+++ b/jet/dashboard/urls.py
@@ -5,8 +5,7 @@ from jet.dashboard.views import update_dashboard_modules_view, add_user_dashboar
     update_dashboard_module_collapse_view, remove_dashboard_module_view, UpdateDashboardModuleView, \
     load_dashboard_module_view, reset_dashboard_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^module/(?P<pk>\d+)/$',
         UpdateDashboardModuleView.as_view(),
@@ -48,6 +47,6 @@ urlpatterns = patterns(
         {'packages': ('jet',)},
         name='jsi18n'
     ),
-)
+]
 
 urlpatterns += dashboard.urls.get_urls()

--- a/jet/urls.py
+++ b/jet/urls.py
@@ -2,8 +2,7 @@ from django.conf.urls import patterns, url
 from django.views.i18n import javascript_catalog
 from jet.views import add_bookmark_view, remove_bookmark_view, toggle_application_pin_view, model_lookup_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^add_bookmark/$',
         add_bookmark_view,
@@ -30,4 +29,4 @@ urlpatterns = patterns(
         {'packages': ('django.conf', 'django.contrib.admin', 'jet',)},
         name='jsi18n'
     ),
-)
+]


### PR DESCRIPTION
python2.7/site-packages/jet/urls.py:31: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='jsi18n'

python2.7/site-packages/jet/dashboard/dashboard.py:6: RemovedInDjango110Warning: django.core.context_processors is deprecated in favor of django.template.context_processors.
  from django.core.context_processors import csrf

python2.7/site-packages/jet/dashboard/urls.py:49: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='jsi18n'
