### PR TITLE
get_app_list is expected to return an iterable

### DIFF
--- a/jet/utils.py
+++ b/jet/utils.py
@@ -39,7 +39,7 @@ def get_app_list(context):
     try:
         return template_response.context_data['app_list']
     except Exception:
-        return None
+        return []
 
 
 def get_admin_site(current_app):


### PR DESCRIPTION
Returning empty list instead of None stops the dashboard from just crashing/displaying an empty page.