### PR TITLE
Remove reference to redundant ie.css file removed in Django 1.9.2

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -15,7 +15,6 @@
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/base.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="base-stylesheet" />
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/select2.theme.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="select2-stylesheet" />
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/jquery-ui.theme.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="jquery-ui-stylesheet" />
-    <!--[if lte IE 7]><link rel="stylesheet" type="text/css" href="{% block stylesheet_ie %}{% static "admin/css/ie.css" %}{% endblock %}" /><![endif]-->
     {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" />{% endif %}
     {% block extrastyle %}{% endblock %}
 

--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -1,5 +1,5 @@
 {% load i18n admin_static jet_tags %}
-{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}{% format_current_language LANGUAGE_CODE as LANGUAGE_CODE %}{% get_themes as THEMES %}{% get_current_theme as THEME %}{% get_current_jet_version as JET_VERSION %}{% get_side_menu_compact as SIDE_MENU_COMPACT %}
+{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}{% format_current_language LANGUAGE_CODE as LANGUAGE_CODE %}{% get_themes as THEMES %}{% get_current_theme as THEME %}{% get_current_jet_version as JET_VERSION %}{% get_side_menu_compact as SIDE_MENU_COMPACT %}{% supports_old_ie as SUPPORTS_OLD_IE %}
 {% block html %}<!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
@@ -15,6 +15,7 @@
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/base.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="base-stylesheet" />
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/select2.theme.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="select2-stylesheet" />
     <link href="{% static "jet/css/themes/"|add:THEME|add:"/jquery-ui.theme.css" %}?v={{ JET_VERSION }}" rel="stylesheet" class="jquery-ui-stylesheet" />
+    {% if SUPPORTS_OLD_IE %}<!--[if lte IE 7]><link rel="stylesheet" type="text/css" href="{% block stylesheet_ie %}{% static "admin/css/ie.css" %}{% endblock %}" /><![endif]-->{% endif %}
     {% if LANGUAGE_BIDI %}<link rel="stylesheet" type="text/css" href="{% block stylesheet_rtl %}{% static "admin/css/rtl.css" %}{% endblock %}" />{% endif %}
     {% block extrastyle %}{% endblock %}
 

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -308,7 +308,7 @@ def get_side_menu_compact():
     return settings.JET_SIDE_MENU_COMPACT
 
 
-@register.simple_tag
+@register.assignment_tag
 def supports_old_ie():
     if StrictVersion(django.get_version()) < StrictVersion('1.9.2'):
         return True

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import django
 from django import template
 from django.core.urlresolvers import reverse
 from django.db.models import OneToOneField
@@ -10,6 +11,7 @@ from jet import settings, VERSION
 from jet.models import Bookmark, PinnedApplication
 import re
 from jet.utils import get_app_list, get_model_instance_label
+from distutils.version import StrictVersion
 
 register = template.Library()
 
@@ -304,3 +306,11 @@ def get_current_jet_version():
 @register.assignment_tag
 def get_side_menu_compact():
     return settings.JET_SIDE_MENU_COMPACT
+
+
+@register.simple_tag
+def supports_old_ie():
+    if StrictVersion(django.get_version()) < StrictVersion('1.9.2'):
+        return True
+    else:
+        return False;


### PR DESCRIPTION
[As of Django 1.9.2](https://github.com/django/django/commit/7a90b53d60f6a66340811417547e33e0bfadf09e) the ie.css file is removed as IE 6 and 7 have reached EOL. I wasn't sure how to keep the file around based on current Django version, although if Django proper has dropped IE6/7 it may be worth considering doing the same. Having a reference to a file that no longer exists also breaks some static file implementations.