### PR TITLE
don't add non-scrollable class to nested popups

### DIFF
--- a/jet/static/admin/js/admin/RelatedObjectLookups.js
+++ b/jet/static/admin/js/admin/RelatedObjectLookups.js
@@ -157,7 +157,7 @@ function showRelatedPopup(name, href) {
     django.jQuery(function($) {
         var $container = $('.related-popup-container', parent.document);
         var $loading = $container.find('.loading-indicator', parent.document);
-        var $body = $('body').addClass('non-scrollable', parent.document);
+        var $body = $('body:not(.popup)').addClass('non-scrollable', parent.document);
         var $popup = $('<iframe>').attr('name', name).attr('src', href).addClass('related-popup').on('load', function() {
             $popup.add($('.related-popup-back')).fadeIn(200, 'swing', function() {
                 $loading.hide();


### PR DESCRIPTION
If you open a related object from inside another related object, when you go back, you can't scroll anymore.