### PR TITLE
Make urlpatterns and csrf import compatible with Django 1.8+

### DIFF
--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from jet.dashboard import modules
 from jet.dashboard.models import UserDashboardModule
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 from django.utils.translation import ugettext_lazy as _
 from jet.ordered_set import OrderedSet
 from jet.utils import get_admin_site_name

--- a/jet/dashboard/urls.py
+++ b/jet/dashboard/urls.py
@@ -5,8 +5,7 @@ from jet.dashboard.views import update_dashboard_modules_view, add_user_dashboar
     update_dashboard_module_collapse_view, remove_dashboard_module_view, UpdateDashboardModuleView, \
     load_dashboard_module_view, reset_dashboard_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^module/(?P<pk>\d+)/$',
         UpdateDashboardModuleView.as_view(),
@@ -48,6 +47,6 @@ urlpatterns = patterns(
         {'packages': ('jet',)},
         name='jsi18n'
     ),
-)
+]
 
 urlpatterns += dashboard.urls.get_urls()

--- a/jet/urls.py
+++ b/jet/urls.py
@@ -1,9 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.i18n import javascript_catalog
 from jet.views import add_bookmark_view, remove_bookmark_view, toggle_application_pin_view, model_lookup_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^add_bookmark/$',
         add_bookmark_view,
@@ -30,4 +29,4 @@ urlpatterns = patterns(
         {'packages': ('django.conf', 'django.contrib.admin', 'jet',)},
         name='jsi18n'
     ),
-)
+]


### PR DESCRIPTION
Change urlpatterns to plain list of django.conf.urls.url() instances as patterns() has been deprecated since 1.8;

Replace django.core.context_processors with django.template.context_processors when importing csrf as django.core.context_processors is deprecated in favor of django.template.context_processors

Removes Django1.10 warnings in django 1.9 