### PR TITLE
Added safe template tag

### DIFF
--- a/jet/templates/registration/password_change_form.html
+++ b/jet/templates/registration/password_change_form.html
@@ -33,7 +33,7 @@
                         {{ form.new_password1.errors }}
                         {{ form.new_password1.label_tag }} {{ form.new_password1 }}
                         {% if form.new_password1.help_text %}
-                            <p class="help">{{ form.new_password1.help_text }}</p>
+                            <p class="help">{{ form.new_password1.help_text|safe }}</p>
                         {% endif %}
                     </div>
 
@@ -41,7 +41,7 @@
                         {{ form.new_password2.errors }}
                         {{ form.new_password2.label_tag }} {{ form.new_password2 }}
                         {% if form.new_password2.help_text %}
-                            <p class="help">{{ form.new_password2.help_text }}</p>
+                            <p class="help">{{ form.new_password2.help_text|safe }}</p>
                         {% endif %}
                     </div>
                 </fieldset>


### PR DESCRIPTION
Django's [own password change template](https://github.com/django/django/blob/master/django/contrib/admin/templates/registration/password_change_form.html#L39) adds the safe template tag to the help text, otherwise the default gets displayed as `<ul><li>Your password can&#39;t be too similar to your other personal information.</li>...` instead of: <ul><li>Your password can&#39;t be too similar to your other personal information.</li>