### PR TITLE
Fixed compatibility issue with Django 1.10.

### DIFF
--- a/jet/urls.py
+++ b/jet/urls.py
@@ -1,5 +1,5 @@
 import django
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.i18n import javascript_catalog
 from jet.views import add_bookmark_view, remove_bookmark_view, toggle_application_pin_view, model_lookup_view
 
@@ -33,4 +33,5 @@ urlpatterns = [
 ]
 
 if django.VERSION[:2] < (1, 8):
+    from django.conf.urls import patterns
     urlpatterns = patterns('', *urlpatterns)


### PR DESCRIPTION
django.conf.urls.patterns is deprecated in 1.10.