### PR TITLE
get_dashboard() template tag: use WSGIRequest().resolver_match instead of resolve()

### DIFF
--- a/jet/dashboard/templatetags/jet_dashboard_tags.py
+++ b/jet/dashboard/templatetags/jet_dashboard_tags.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django import template
-from django.core.urlresolvers import resolve
 from jet.dashboard.utils import get_current_dashboard
 
 register = template.Library()
@@ -10,7 +9,6 @@ register = template.Library()
 def get_dashboard(context, location):
     dashboard_cls = get_current_dashboard(location)
 
-    resolver = resolve(context['request'].path)
-    app_label = resolver.kwargs.get('app_label')
+    app_label = context['request'].resolver_match.kwargs.get('app_label')
 
     return dashboard_cls(context, app_label=app_label)


### PR DESCRIPTION
Hi there,

I ran into an issue when trying to use `django-jet` with our project, and it comes from the fact that we use an [HTTP script name](https://docs.djangoproject.com/en/1.10/ref/settings/#force-script-name). The consequence it has is that the [`WSGIRequest.path`](https://github.com/django/django/blob/3c447b108ac70757001171f7a4791f493880bf5b/django/core/handlers/wsgi.py#L92-L93) contains the script name in it. There are two ways to fix it:
- use `path_info` instead [here](https://github.com/geex-arts/django-jet/blob/1.0.2/jet/dashboard/templatetags/jet_dashboard_tags.py#L13)
- use `WSGIRequest().resolver_match` instead

I chose the second solution since it should also improve performances, i.e. not unnecessary calling `resolve()` function. And it's at least compatible for Django 1.6 and above.

LMK what you think :)

(also, I didn't find specific tests for that but let me know where I can add one)