### PR TITLE
Fix encoding error in jet_popup_response_data.

### DIFF
--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -7,6 +7,7 @@ from django.forms import CheckboxInput, ModelChoiceField, Select, ModelMultipleC
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
+from django.utils.encoding import smart_text
 from jet import settings, VERSION
 from jet.models import Bookmark, PinnedApplication
 from jet.utils import get_app_list, get_model_instance_label, get_model_queryset, get_possible_language_codes, \
@@ -267,7 +268,7 @@ def jet_popup_response_data(context):
     return json.dumps({
         'action': context.get('action'),
         'value': context.get('value') or context.get('pk_value'),
-        'obj': str(context.get('obj')),
+        'obj': smart_text(context.get('obj')),
         'new_value': context.get('new_value')
     })
 


### PR DESCRIPTION
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 13: ordinal not in range(128)
(5 additional frame(s) were not displayed)
...
  File "jet/templatetags/jet_tags.py", line 270, in jet_popup_response_data
    'obj': str(context.get('obj')),