### PR TITLE
minimal-ui is not supported after safari 8.

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -6,7 +6,7 @@
 <head>
 <title>{% block title %}{% endblock %}</title>
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" />
 
 <link rel="stylesheet" type="text/css" href="{% static "jet/css/vendor.css" as url %}{{ url|jet_append_version }}" />


### PR DESCRIPTION
The minimal-ui property of viewport is not supported after the 8th major version of Safari. Then Safari will be return a error message in console when minimal property found in viewport.