### PR TITLE
Add fallback to window.opener which supports old django popups.

### DIFF
--- a/jet/static/jet/js/src/features/related-popups.js
+++ b/jet/static/jet/js/src/features/related-popups.js
@@ -217,7 +217,7 @@ RelatedPopups.prototype = {
             = window.showRelatedObjectPopup
             = function() { };
 
-        window.opener = this.windowStorage.previous();
+        window.opener = this.windowStorage.previous() || window.opener;
         window.dismissRelatedLookupPopup = function(win, chosenId) {
             self.closePopup({
                 action: 'lookup',


### PR DESCRIPTION
This support old django popups for example django-filer has own many popups which not works when opener is not present.

This not affect generic django popups.