### PR TITLE
Fix RelatedFieldAjaxListFilter implementation

### DIFF
--- a/jet/filters.py
+++ b/jet/filters.py
@@ -22,6 +22,14 @@ class RelatedFieldAjaxListFilter(RelatedFieldListFilter):
         return True
 
     def field_choices(self, field, request, model_admin):
+        """
+        This method should return every available choices for the list filter,
+        as a list of tuples. Each tuple contains the pk and the string representation of
+        a related model instance.
+
+        For more information, see RelatedFieldListFilter implementation:
+        https://github.com/django/django/blob/1.10.5/django/contrib/admin/filters.py#L161-L223
+        """
         model = field.remote_field.model if hasattr(field, 'remote_field') else field.related_field.model
         app_label = model._meta.app_label
         model_name = model._meta.object_name
@@ -32,17 +40,13 @@ class RelatedFieldAjaxListFilter(RelatedFieldListFilter):
             'data-ajax--url': reverse('jet:model_lookup'),
             'data-queryset--lookup': self.lookup_kwarg
         }))
-
-        if self.lookup_val is None:
-            return []
-
         other_model = get_model_from_relation(field)
         if hasattr(field, 'rel'):
             rel_name = field.rel.get_related_field().name
         else:
             rel_name = other_model._meta.pk.name
 
-        queryset = model._default_manager.filter(**{rel_name: self.lookup_val}).all()
+        queryset = model._default_manager.all()
         return [(x._get_pk_val(), smart_text(x)) for x in queryset]
 
 

--- a/jet/tests/test_filters.py
+++ b/jet/tests/test_filters.py
@@ -39,16 +39,19 @@ class FiltersTestCase(TestCase):
 
         self.assertTrue(list_filter.has_output())
 
-        choices = list_filter.field_choices(field, request, model_admin)
+        field_choices = list_filter.field_choices(field, request, model_admin)
 
-        self.assertIsInstance(choices, list)
-        self.assertEqual(len(choices), 1)
+        self.assertEqual(field_choices, [
+            (self.models[0].pk, smart_text(self.models[0])),
+            (self.models[1].pk, smart_text(self.models[1])),
+        ])
 
         # check choice selection
         choices = list(list_filter.choices(self.fake_change_list))
         choices[0]['display'] = str(choices[0]['display'])  # gettext_lazy()
         self.assertEqual(choices, [
-            {'display': 'All', 'query_string': '', 'selected': False},
+            {'display': 'All', 'query_string': '', 'selected': True},
+            {'display': 'first1', 'query_string': '', 'selected': False},
             {'display': 'second2', 'query_string': '', 'selected': False},
         ])
 
@@ -60,16 +63,18 @@ class FiltersTestCase(TestCase):
 
         self.assertTrue(list_filter.has_output())
 
-        choices = list_filter.field_choices(field, request, model_admin)
+        field_choices = list_filter.field_choices(field, request, model_admin)
 
-        self.assertIsInstance(choices, list)
-        self.assertEqual(len(choices), 1)
-        self.assertEqual(choices[0], (initial.pk, smart_text(initial)))
+        self.assertEqual(field_choices, [
+            (self.models[0].pk, smart_text(self.models[0])),
+            (self.models[1].pk, smart_text(self.models[1])),
+        ])
 
         # check choice selection
         choices = list(list_filter.choices(self.fake_change_list))
         choices[0]['display'] = str(choices[0]['display'])  # gettext_lazy()
         self.assertEqual(choices, [
             {'display': 'All', 'query_string': '', 'selected': False},
+            {'display': 'first1', 'query_string': '', 'selected': False},
             {'display': 'second2', 'query_string': '', 'selected': True},
         ])

--- a/jet/tests/test_filters.py
+++ b/jet/tests/test_filters.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.test import TestCase, RequestFactory
 from django.utils.encoding import smart_text
+from django.utils.translation import ugettext_lazy as _
 from jet.filters import RelatedFieldAjaxListFilter
 from jet.tests.models import RelatedToTestModel, TestModel
 
@@ -48,9 +49,8 @@ class FiltersTestCase(TestCase):
 
         # check choice selection
         choices = list(list_filter.choices(self.fake_change_list))
-        choices[0]['display'] = str(choices[0]['display'])  # gettext_lazy()
         self.assertEqual(choices, [
-            {'display': 'All', 'query_string': '', 'selected': True},
+            {'display': _('All'), 'query_string': '', 'selected': True},
             {'display': 'first1', 'query_string': '', 'selected': False},
             {'display': 'second2', 'query_string': '', 'selected': False},
         ])
@@ -72,9 +72,8 @@ class FiltersTestCase(TestCase):
 
         # check choice selection
         choices = list(list_filter.choices(self.fake_change_list))
-        choices[0]['display'] = str(choices[0]['display'])  # gettext_lazy()
         self.assertEqual(choices, [
-            {'display': 'All', 'query_string': '', 'selected': False},
+            {'display': _('All'), 'query_string': '', 'selected': False},
             {'display': 'first1', 'query_string': '', 'selected': False},
             {'display': 'second2', 'query_string': '', 'selected': True},
         ])


### PR DESCRIPTION
Hi there,

I took a look at `RelatedFieldAjaxListFilter` because I needed to use it, and it occurred to me that the implementation was wrong. `RelatedFieldAjaxListFilter.field_choices()` should return the list of [all possible results](https://github.com/django/django/blob/1.10.5/django/contrib/admin/filters.py#L196-L197), and not filter the queryset. The selection display is then done in the `RelatedFieldAjaxListFilter.choices()`, and the filtering is done in the [`queryset()` method](https://github.com/django/django/blob/1.10.5/django/contrib/admin/filters.py#L135-L139).

It fixed the problem on our end, let me know if you can merge that or if it needs more work.
Thanks!