### PR TITLE
add JET_EXTRA_SIDE_MENU_ITEMS to be add extra items to menu *dynamica…

### DIFF
--- a/jet/settings.py
+++ b/jet/settings.py
@@ -8,6 +8,7 @@ JET_THEMES = getattr(settings, 'JET_THEMES', [])
 JET_SIDE_MENU_COMPACT = getattr(settings, 'JET_SIDE_MENU_COMPACT', False)
 JET_SIDE_MENU_ITEMS = getattr(settings, 'JET_SIDE_MENU_ITEMS', None)
 JET_SIDE_MENU_CUSTOM_APPS = getattr(settings, 'JET_SIDE_MENU_CUSTOM_APPS', None)
+JET_EXTRA_SIDE_MENU_ITEMS = getattr(settings, 'JET_EXTRA_SIDE_MENU_ITEMS', None)
 
 # Improved usability
 JET_CHANGE_FORM_SIBLING_LINKS = getattr(settings, 'JET_CHANGE_FORM_SIBLING_LINKS', True)

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -297,6 +297,7 @@ def get_menu_item_url(url, original_app_list):
 def get_menu_items(context):
     pinned_apps = PinnedApplication.objects.filter(user=context['user'].pk).values_list('app_label', flat=True)
     original_app_list = OrderedDict(map(lambda app: (app['app_label'], app), get_original_menu_items(context)))
+    extra_menu_items = settings.JET_EXTRA_SIDE_MENU_ITEMS
     custom_app_list = settings.JET_SIDE_MENU_ITEMS
     custom_app_list_deprecated = settings.JET_SIDE_MENU_CUSTOM_APPS
 
@@ -436,6 +437,8 @@ def get_menu_items(context):
             else:
                 app['current'] = False
 
+    if extra_menu_items not in (None, False):
+        app_list += extra_menu_items
     return app_list
 
 


### PR DESCRIPTION
Add JET_EXTRA_SIDE_MENU_ITEMS to be add extra items to menu *dynamically*
Using JET_SIDE_MENU_ITEMS overrides whatever is generated for app_list and hence you should update this list every time you add new admin item using you will be able to append items to the menu in the following format:
``` python
JET_EXTRA_SIDE_MENU_ITEMS = [{
        "pinned": False,
        "has_perms": True,
        "items": [
            {
                "name": "Reprting",
                "url": "/reporting/",
                "label": "Reporting",
                "current": False,
                "has_perms": True,
                "url_blank": False
            }
        ],
        "url": "/reporting/",
        "url_blank": False,
        "current": False,
        "custom": True,
        "label": "Reporting"
    }]
```