### PR TITLE
 add scripts to packages.json for more faster running

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "django-jet",
+  "scripts":{
+      "watch": "gulp watch",
+      "build": "gulp build",
+      "dev": "gulp default"
+  },
   "devDependencies": {
     "autoprefixer": "6.4.0",
     "browserify": "13.0.1",


### PR DESCRIPTION
now you can compile and bundle with:

npm run dev

npm run watch

npm run build

not needed more:

./node_modules/.bin/gulp default
