### PR TITLE
minor update, to avoid mistakes

### DIFF
--- a/docs/dashboard_custom.rst
+++ b/docs/dashboard_custom.rst
@@ -55,7 +55,7 @@ Set Up Custom Dashboard
               ))
 
 
-* Add to your settings.py path to created ``dashboard.py`` (example for ``dashboard.py`` in project root):
+* Add to your settings.py path to created ``dashboard.py`` (example for ``dashboard.py`` in project root, ie. together with manage.py):
 
 .. code:: python
 


### PR DESCRIPTION
Seems some people make easy the mistake, when they add dashboard.py together with settings,py, instead of together with manage.py.
This leads to difficult errors:
https://github.com/geex-arts/django-jet/issues/156
Maybe this issue can be closed then, because author have added that he made a mistake.

This is the change:
(example for ``dashboard.py`` in project root) => (example for ``dashboard.py`` in project root, ie. together with manage.py)

No idea why 2nd change is in diff - both rows seems to be (and should to be) same.