### PR TITLE
Add nested fields to jquery error search

### DIFF
--- a/jet/static/jet/js/src/features/changeform-tabs.js
+++ b/jet/static/jet/js/src/features/changeform-tabs.js
@@ -74,7 +74,7 @@ ChangeFormTabs.prototype = {
             if (selector) {
                 var $contentWrapper = $contentWrappers.filter('.' + selector);
 
-                if ($contentWrapper.find('.form-row.errors').length) {
+                if ($contentWrapper.find('.form-row.errors, .field-box.errors').length) {
                     $tabItem.addClass('errors');
                 }
             }


### PR DESCRIPTION
This fixes #302 by searching for `.field-box.errors` in addition to `.form-row.errors`.  There doesn't appear to be any test coverage of this feature, so I'm unsure where to add it if desired.