### PR TITLE
change user.pk to user(ForeignKey) to support custom id

### DIFF
--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -120,7 +120,7 @@ class Dashboard(object):
             module_models.append(UserDashboardModule.objects.create(
                 title=module.title,
                 app_label=self.app_label,
-                user=user.pk,
+                user=user,
                 module=module.fullname(),
                 column=column,
                 order=order,
@@ -134,7 +134,7 @@ class Dashboard(object):
     def load_modules(self):
         module_models = UserDashboardModule.objects.filter(
             app_label=self.app_label,
-            user=self.context['request'].user.pk
+            user=self.context['request'].user
         ).all()
 
         if len(module_models) == 0:

--- a/jet/dashboard/forms.py
+++ b/jet/dashboard/forms.py
@@ -26,7 +26,7 @@ class UpdateDashboardModulesForm(forms.Form):
 
             for module in modules:
                 db_module = UserDashboardModule.objects.get(
-                    user=self.request.user.pk,
+                    user=self.request.user,
                     app_label=data['app_label'] if data['app_label'] else None,
                     pk=module['id']
                 )
@@ -90,7 +90,7 @@ class AddUserDashboardModuleForm(forms.ModelForm):
     def save(self, commit=True):
         self.instance.title = self.module_cls.title
         self.instance.module = self.module_cls.fullname()
-        self.instance.user = self.request.user.pk
+        self.instance.user = self.request.user
         self.instance.column = 0
         self.instance.order = -1
         self.instance.settings = self.module_cls.dump_settings()
@@ -114,7 +114,7 @@ class UpdateDashboardModuleCollapseForm(forms.ModelForm):
         if not user_is_authenticated(self.request.user) or not self.request.user.is_staff:
             raise ValidationError('error')
 
-        if self.instance.user != self.request.user.pk:
+        if self.instance.user != self.request.user:
             raise ValidationError('error')
 
         return data
@@ -132,7 +132,7 @@ class RemoveDashboardModuleForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(RemoveDashboardModuleForm, self).clean()
 
-        if not user_is_authenticated(self.request.user) or self.instance.user != self.request.user.pk:
+        if not user_is_authenticated(self.request.user) or self.instance.user != self.request.user:
             raise ValidationError('error')
 
         return cleaned_data
@@ -165,6 +165,6 @@ class ResetDashboardForm(forms.Form):
     def save(self, commit=True):
         if commit:
             UserDashboardModule.objects.filter(
-                user=self.request.user.pk,
+                user=self.request.user,
                 app_label=self.cleaned_data['app_label']
             ).delete()

--- a/jet/dashboard/migrations/0001_initial.py
+++ b/jet/dashboard/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(verbose_name='Title', max_length=255)),
                 ('module', models.CharField(verbose_name='module', max_length=255)),
                 ('app_label', models.CharField(verbose_name='application name', max_length=255, blank=True, null=True)),
-                ('user', models.PositiveIntegerField(verbose_name='user')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='user')),
                 ('column', models.PositiveIntegerField(verbose_name='column')),
                 ('order', models.IntegerField(verbose_name='order')),
                 ('settings', models.TextField(verbose_name='settings', blank=True, default='')),

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 import json
 from django.db import models
+from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
@@ -11,7 +12,8 @@ class UserDashboardModule(models.Model):
     title = models.CharField(verbose_name=_('Title'), max_length=255)
     module = models.CharField(verbose_name=_('module'), max_length=255)
     app_label = models.CharField(verbose_name=_('application name'), max_length=255, null=True, blank=True)
-    user = models.PositiveIntegerField(verbose_name=_('user'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+                             verbose_name=_('user'))
     column = models.PositiveIntegerField(verbose_name=_('column'))
     order = models.IntegerField(verbose_name=_('order'))
     settings = models.TextField(verbose_name=_('settings'), default='', blank=True)
@@ -55,5 +57,3 @@ class UserDashboardModule(models.Model):
 
         self.settings = json.dumps(settings, cls=LazyDateTimeEncoder)
         self.save()
-
-

--- a/jet/dashboard/south_migrations/0001_initial.py
+++ b/jet/dashboard/south_migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(SchemaMigration):
             ('title', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('module', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('app_label', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, blank=True)),
-            ('user', self.gf('django.db.models.fields.PositiveIntegerField')()),
+            ('user', self.gf('django.db.models.fields.ForeignKey')()),
             ('column', self.gf('django.db.models.fields.PositiveIntegerField')()),
             ('order', self.gf('django.db.models.fields.IntegerField')()),
             ('settings', self.gf('django.db.models.fields.TextField')(default='', blank=True)),
@@ -41,7 +41,7 @@ class Migration(SchemaMigration):
             'order': ('django.db.models.fields.IntegerField', [], {}),
             'settings': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
-            'user': ('django.db.models.fields.PositiveIntegerField', [], {})
+            'user': ('django.db.models.fields.ForeignKey', [], {})
         }
     }
 

--- a/jet/dashboard/views.py
+++ b/jet/dashboard/views.py
@@ -219,7 +219,7 @@ def load_dashboard_module_view(request, pk):
         if not user_is_authenticated(request.user) or not request.user.is_staff:
             raise ValidationError('error')
 
-        instance = UserDashboardModule.objects.get(pk=pk, user=request.user.pk)
+        instance = UserDashboardModule.objects.get(pk=pk, user=request.user)
         module_cls = instance.load_module()
         module = module_cls(model=instance, context={'request': request})
         result['html'] = module.render()

--- a/jet/forms.py
+++ b/jet/forms.py
@@ -35,7 +35,7 @@ class AddBookmarkForm(forms.ModelForm):
         return data
 
     def save(self, commit=True):
-        self.instance.user = self.request.user.pk
+        self.instance.user = self.request.user
         return super(AddBookmarkForm, self).save(commit)
 
 
@@ -52,7 +52,7 @@ class RemoveBookmarkForm(forms.ModelForm):
         data = super(RemoveBookmarkForm, self).clean()
         if not user_is_authenticated(self.request.user) or not self.request.user.is_staff:
             raise ValidationError('error')
-        if self.instance.user != self.request.user.pk:
+        if self.instance.user != self.request.user:
             raise ValidationError('error')
         return data
 
@@ -81,14 +81,14 @@ class ToggleApplicationPinForm(forms.ModelForm):
             try:
                 pinned_app = PinnedApplication.objects.get(
                     app_label=self.cleaned_data['app_label'],
-                    user=self.request.user.pk
+                    user=self.request.user
                 )
                 pinned_app.delete()
                 return False
             except PinnedApplication.DoesNotExist:
                 PinnedApplication.objects.create(
                     app_label=self.cleaned_data['app_label'],
-                    user=self.request.user.pk
+                    user=self.request.user
                 )
                 return True
 

--- a/jet/migrations/0001_initial.py
+++ b/jet/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('url', models.URLField(verbose_name='URL')),
                 ('title', models.CharField(max_length=255, verbose_name='title')),
-                ('user', models.PositiveIntegerField(verbose_name='user')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='user')),
                 ('date_add', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date created')),
             ],
             options={
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('app_label', models.CharField(max_length=255, verbose_name='application name')),
-                ('user', models.PositiveIntegerField(verbose_name='user')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL, verbose_name='user')),
                 ('date_add', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date created')),
             ],
             options={

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
@@ -8,7 +9,8 @@ from django.utils.translation import ugettext_lazy as _
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))
     title = models.CharField(verbose_name=_('title'), max_length=255)
-    user = models.PositiveIntegerField(verbose_name=_('user'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+                             verbose_name=_('user'))
     date_add = models.DateTimeField(verbose_name=_('date created'), default=timezone.now)
 
     class Meta:
@@ -23,7 +25,8 @@ class Bookmark(models.Model):
 @python_2_unicode_compatible
 class PinnedApplication(models.Model):
     app_label = models.CharField(verbose_name=_('application name'), max_length=255)
-    user = models.PositiveIntegerField(verbose_name=_('user'))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+                             verbose_name=_('user'))
     date_add = models.DateTimeField(verbose_name=_('date created'), default=timezone.now)
 
     class Meta:
@@ -33,4 +36,3 @@ class PinnedApplication(models.Model):
 
     def __str__(self):
         return self.app_label
-

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -51,7 +51,7 @@ def jet_get_menu(context):
 def jet_get_bookmarks(user):
     if user is None:
         return None
-    return Bookmark.objects.filter(user=user.pk)
+    return Bookmark.objects.filter(user=user)
 
 
 @register.filter

--- a/jet/tests/test_dashboard.py
+++ b/jet/tests/test_dashboard.py
@@ -33,7 +33,7 @@ class DashboardTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.LinkList',
             app_label=None,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=0
         )
@@ -41,7 +41,7 @@ class DashboardTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.RecentActions',
             app_label=None,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=1
         )

--- a/jet/tests/test_views.py
+++ b/jet/tests/test_views.py
@@ -31,7 +31,7 @@ class ViewsTestCase(TestCase):
             title=title,
             module='jet.dashboard.modules.LinkList',
             app_label=None,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=0,
             settings='{"layout": "inline"}',
@@ -94,7 +94,7 @@ class ViewsTestCase(TestCase):
     def test_remove_bookmark_view(self):
         url = 'http://test.com/'
         title = 'Title'
-        bookmark = Bookmark.objects.create(url=url, title=title, user=self.admin_user.pk)
+        bookmark = Bookmark.objects.create(url=url, title=title, user=self.admin_user)
         response = self.admin.post(reverse('jet:remove_bookmark'), {'id': bookmark.id})
         self.assertEqual(response.status_code, 200)
         response = json.loads(response.content.decode())
@@ -122,7 +122,7 @@ class ViewsTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.LinkList',
             app_label=app_label,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=0
         )
@@ -130,7 +130,7 @@ class ViewsTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.LinkList',
             app_label=app_label,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=1
         )
@@ -190,7 +190,7 @@ class ViewsTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.LinkList',
             app_label=None,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=0
         )
@@ -218,7 +218,7 @@ class ViewsTestCase(TestCase):
             title='',
             module='jet.dashboard.modules.LinkList',
             app_label=None,
-            user=self.admin_user.pk,
+            user=self.admin_user,
             column=0,
             order=0
         )


### PR DESCRIPTION
Converted user from PositiveIntegerField to ForeignKey to extend support custom user models and ids such as UUID.