### PR TITLE
Pass ModelChoiceField queryset filters to autocomplete view

### DIFF
--- a/jet/forms.py
+++ b/jet/forms.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     from django.db.models.loading import get_model
 
+import pickle
+import codecs
 
 class AddBookmarkForm(forms.ModelForm):
     def __init__(self, request, *args, **kwargs):
@@ -126,7 +128,8 @@ class ModelLookupForm(forms.Form):
         return data
 
     def lookup(self):
-        qs = self.model_cls.objects
+        qs = self.model_cls.objects.all()
+        qs.query.__dict__ = pickle.loads(codecs.decode(self.data['filters'].encode(), 'base64'))
 
         if self.cleaned_data['q']:
             if getattr(self.model_cls, 'autocomplete_search_fields', None):

--- a/jet/static/jet/js/src/features/selects.js
+++ b/jet/static/jet/js/src/features/selects.js
@@ -156,6 +156,7 @@ Select2.prototype = {
             var appLabel = $select.data('app-label');
             var model = $select.data('model');
             var objectId = $select.data('object-id');
+            var filters = $select.data('filters')
             var pageSize = 100;
 
             settings['ajax'] = {
@@ -168,7 +169,8 @@ Select2.prototype = {
                         q: params.term,
                         page: params.page,
                         page_size: pageSize,
-                        object_id: objectId
+                        object_id: objectId,
+                        filters: filters
                     };
                 },
                 processResults: function (data, params) {

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     from urlparse import parse_qsl
 
+import pickle
+import codecs
 
 register = template.Library()
 assignment_tag = register.assignment_tag if hasattr(register, 'assignment_tag') else register.simple_tag
@@ -75,7 +77,8 @@ def jet_select2_lookups(field):
                 'class': 'ajax',
                 'data-app-label': app_label,
                 'data-model': model_name,
-                'data-ajax--url': reverse('jet:model_lookup')
+                'data-ajax--url': reverse('jet:model_lookup'),
+                'data-filters': codecs.encode(pickle.dumps(field.field.queryset.query.__dict__), 'base64').decode()
             }
 
             initial_value = field.value()


### PR DESCRIPTION
Hi. 

This patch pass the queryset filters of the ModelChoiceField along with the ajax request to the autocomplete views, so the options that select2 widget shows is also filtered with the same filters that the ModelChoiceField. 