### PR TITLE
Fixed google analytics on django 2.1

### DIFF
--- a/jet/dashboard/dashboard_modules/google_analytics.py
+++ b/jet/dashboard/dashboard_modules/google_analytics.py
@@ -144,7 +144,7 @@ class GoogleAnalyticsClient:
 class CredentialWidget(Widget):
     module = None
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value and len(value) > 0:
             link = '<a href="%s">%s</a>' % (
                 reverse('jet-dashboard:google-analytics-revoke', kwargs={'pk': self.module.model.pk}),


### PR DESCRIPTION
Fix render() got an unexpected keyword argument 'renderer' on django\forms\boundfield.py in as_widget, line 93