### PR TITLE
Remove duplicate entries in autocomplete

### DIFF
--- a/jet/forms.py
+++ b/jet/forms.py
@@ -134,7 +134,7 @@ class ModelLookupForm(forms.Form):
                 filter_data = [Q((field + '__icontains', self.cleaned_data['q'])) for field in search_fields]
                 # if self.cleaned_data['object_id']:
                 #     filter_data.append(Q(pk=self.cleaned_data['object_id']))
-                qs = qs.filter(reduce(operator.or_, filter_data))
+                qs = qs.filter(reduce(operator.or_, filter_data)).distinct()
             else:
                 qs = qs.none()
 


### PR DESCRIPTION
When "autocomplete_search_fields" contains a ManyToMany related field, the resulting queryset has duplicates. Adding a distinct() removes them.