### PR TITLE
Fix unicode crash in jet_tags.py

### DIFF
--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -11,7 +11,7 @@ from django.forms import CheckboxInput, ModelChoiceField, Select, ModelMultipleC
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_text, smart_str
 from jet import settings, VERSION
 from jet.models import Bookmark
 from jet.utils import get_model_instance_label, get_model_queryset, get_possible_language_codes, \
@@ -194,7 +194,7 @@ def jet_sibling_object(context, next):
         url += '?' + preserved_filters_plain
 
     return {
-        'label': str(sibling_object),
+        'label': smart_str(sibling_object),
         'url': url
     }
 


### PR DESCRIPTION
This fixes #357 moving str() to smart_str().