### PR TITLE
Fix Django 2.1+ Compatibality

### DIFF
--- a/jet/dashboard/dashboard_modules/google_analytics.py
+++ b/jet/dashboard/dashboard_modules/google_analytics.py
@@ -144,7 +144,7 @@ class GoogleAnalyticsClient:
 class CredentialWidget(Widget):
     module = None
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value and len(value) > 0:
             link = '<a href="%s">%s</a>' % (
                 reverse('jet-dashboard:google-analytics-revoke', kwargs={'pk': self.module.model.pk}),

--- a/jet/dashboard/dashboard_modules/yandex_metrika.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika.py
@@ -100,7 +100,7 @@ class YandexMetrikaClient:
 class AccessTokenWidget(Widget):
     module = None
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value and len(value) > 0:
             link = '<a href="%s">%s</a>' % (
                 reverse('jet-dashboard:yandex-metrika-revoke', kwargs={'pk': self.module.model.pk}),


### PR DESCRIPTION
According to [features-removed-in-2-1](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1), we should now add a kwarg `renderer=None`.