### PR TITLE
Fixes django.jQuery bug when using jinja2 rendered dropdown selects.

### DIFF
--- a/jet/templates/admin/base.html
+++ b/jet/templates/admin/base.html
@@ -28,7 +28,10 @@
 </script>
 <script type="text/javascript" src="{% url 'jet:jsi18n' %}"></script>
 <script src="{% static "jet/js/build/bundle.min.js" as url %}{{ url|jet_append_version }}"></script>
-
+<script src="{% static 'admin/js/vendor/jquery/jquery.js' as url %}{{ url|jet_append_version }}"
+            type="text/javascript"></script>
+<script src="{% static 'admin/js/jquery.init.js' as url %}{{ url|jet_append_version }}"></script>
+    
 {% jet_static_translation_urls as translation_urls %}
 {% for url in translation_urls %}
     <script src="{% static url as url %}{{ url|jet_append_version }}"></script>


### PR DESCRIPTION
Closes https://github.com/geex-arts/django-jet/issues/161

Uses the `jquery.init.js` patch that currently exists in the codebase, but isn't applied to the admin panel base template.