### PR TITLE
Make jet work with Django 3 (tested on Django 3.0.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ env:
   - DJANGO="<1.11"
   - DJANGO="<1.12"
   - DJANGO="<2.1"
+  - DJANGO="<3.0.1"
 before_install:
   - export DJANGO_SETTINGS_MODULE=jet.tests.settings
 install:
   - pip install -q "Django${DJANGO}"
   - pip install .
   - pip install coverage==3.7.1
-  - pip install coveralls # ==0.5
+  - pip install coveralls
 script:
   - coverage run --source=jet --omit=*/migrations/*,*/south_migrations/*,*/tests/* manage.py test jet
 after_success:
@@ -43,9 +44,13 @@ matrix:
       env: DJANGO="<1.12"
     - python: 2.6
       env: DJANGO="<2.1"
+    - python: 2.6
+      env: DJANGO="<3.0.1"
 
     - python: 2.7
       env: DJANGO="<2.1"
+    - python: 2.7
+      env: DJANGO="<3.0.1"
 
     - python: 3.2
       env: DJANGO="<1.10"
@@ -76,3 +81,5 @@ matrix:
 
     - python: pypy
       env: DJANGO="<2.1"
+    - python: pypy
+      env: DJANGO="<3.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-dist: trusty
+# dist: trusty
 language: python
 python:
-  - 2.6
+  # - 2.6
   - 2.7
   - 3.2
-  - 3.3
+  # - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -32,20 +32,20 @@ after_success:
   - coveralls
 matrix:
   exclude:
-    - python: 2.6
-      env: DJANGO="<1.8"
-    - python: 2.6
-      env: DJANGO="<1.9"
-    - python: 2.6
-      env: DJANGO="<1.10"
-    - python: 2.6
-      env: DJANGO="<1.11"
-    - python: 2.6
-      env: DJANGO="<1.12"
-    - python: 2.6
-      env: DJANGO="<2.1"
-    - python: 2.6
-      env: DJANGO="<3.0.1"
+    # - python: 2.6
+    #   env: DJANGO="<1.8"
+    # - python: 2.6
+    #   env: DJANGO="<1.9"
+    # - python: 2.6
+    #   env: DJANGO="<1.10"
+    # - python: 2.6
+    #   env: DJANGO="<1.11"
+    # - python: 2.6
+    #   env: DJANGO="<1.12"
+    # - python: 2.6
+    #   env: DJANGO="<2.1"
+    # - python: 2.6
+    #   env: DJANGO="<3.0.1"
 
     - python: 2.7
       env: DJANGO="<2.1"
@@ -61,14 +61,14 @@ matrix:
     - python: 3.2
       env: DJANGO="<2.1"
 
-    - python: 3.3
-      env: DJANGO="<1.10"
-    - python: 3.3
-      env: DJANGO="<1.11"
-    - python: 3.3
-      env: DJANGO="<1.12"
-    - python: 3.3
-      env: DJANGO="<2.1"
+    # - python: 3.3
+    #   env: DJANGO="<1.10"
+    # - python: 3.3
+    #   env: DJANGO="<1.11"
+    # - python: 3.3
+    #   env: DJANGO="<1.12"
+    # - python: 3.3
+    #   env: DJANGO="<2.1"
 
     - python: 3.5
       env: DJANGO="<1.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install -q "Django${DJANGO}"
   - pip install .
   - pip install coverage==3.7.1
-  - pip install coveralls==0.5
+  - pip install coveralls # ==0.5
 script:
   - coverage run --source=jet --omit=*/migrations/*,*/south_migrations/*,*/tests/* manage.py test jet
 after_success:

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,12 +1,14 @@
 from importlib import import_module
 import json
 from django.db import models
-# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    python_2_unicode_compatible = None
 
 
-# @python_2_unicode_compatible
 class UserDashboardModule(models.Model):
     title = models.CharField(verbose_name=_('Title'), max_length=255)
     module = models.CharField(verbose_name=_('module'), max_length=255)
@@ -56,4 +58,5 @@ class UserDashboardModule(models.Model):
         self.settings = json.dumps(settings, cls=LazyDateTimeEncoder)
         self.save()
 
-
+if python_2_unicode_compatible:
+    UserDashboardModule = python_2_unicode_compatible(UserDashboardModule)

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,12 +1,12 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class UserDashboardModule(models.Model):
     title = models.CharField(verbose_name=_('Title'), max_length=255)
     module = models.CharField(verbose_name=_('module'), max_length=255)

--- a/jet/dashboard/templates/admin/index.html
+++ b/jet/dashboard/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static jet_dashboard_tags static %}
+{% load i18n jet_dashboard_tags static %}
 
 {% block html %}{% get_dashboard 'index' as dashboard %}{{ block.super }}{% endblock %}
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,10 +1,10 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))
     title = models.CharField(verbose_name=_('title'), max_length=255)
@@ -20,7 +20,7 @@ class Bookmark(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class PinnedApplication(models.Model):
     app_label = models.CharField(verbose_name=_('application name'), max_length=255)
     user = models.PositiveIntegerField(verbose_name=_('user'))

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,10 +1,12 @@
 from django.db import models
 from django.utils import timezone
-# from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    python_2_unicode_compatible = None
 
 
-# @python_2_unicode_compatible
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))
     title = models.CharField(verbose_name=_('title'), max_length=255)
@@ -20,7 +22,6 @@ class Bookmark(models.Model):
         return self.title
 
 
-# @python_2_unicode_compatible
 class PinnedApplication(models.Model):
     app_label = models.CharField(verbose_name=_('application name'), max_length=255)
     user = models.PositiveIntegerField(verbose_name=_('user'))
@@ -34,3 +35,6 @@ class PinnedApplication(models.Model):
     def __str__(self):
         return self.app_label
 
+if python_2_unicode_compatible:
+    Bookmark = python_2_unicode_compatible(Bookmark)
+    PinnedApplication = python_2_unicode_compatible(PinnedApplication)

--- a/jet/templates/admin/edit_inline/compact.html
+++ b/jet/templates/admin/edit_inline/compact.html
@@ -1,5 +1,7 @@
-{% load i18n admin_urls admin_static %}
-
+{% load i18n admin_urls jet_tags %}
+{% if jet_have_admin_static %}
+    {% load admin_static %}
+{% endif %}
 <div class="inline-group compact" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-prefix="{{ inline_admin_formset.formset.prefix }}" data-inline-verbose-name="{{ inline_admin_formset.opts.verbose_name|capfirst }}" data-inline-delete-text="{% trans "Remove" %}">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
     {{ inline_admin_formset.formset.management_form }}

--- a/jet/templates/rangefilter/date_filter.html
+++ b/jet/templates/rangefilter/date_filter.html
@@ -1,4 +1,7 @@
-{% load i18n admin_static %}
+{% load i18n %}
+{% if jet_have_admin_static %}
+    {% load admin_static %}
+{% endif %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <script>
     function datefilter_apply(event, qs_name, form_name){

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -12,6 +12,7 @@ from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
+from django import VERSION
 from jet import settings, VERSION
 from jet.models import Bookmark
 from jet.utils import get_model_instance_label, get_model_queryset, get_possible_language_codes, \
@@ -252,3 +253,8 @@ def jet_static_translation_urls():
                 break
 
     return urls
+
+
+@register.filter
+def jet_have_admin_static():
+    return VERSION[0] < 3

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import json
 import os
+import django
 from django import template
 try:
     from django.core.urlresolvers import reverse
@@ -12,7 +13,6 @@ from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
-from django import VERSION
 from jet import settings, VERSION
 from jet.models import Bookmark
 from jet.utils import get_model_instance_label, get_model_queryset, get_possible_language_codes, \
@@ -257,4 +257,4 @@ def jet_static_translation_urls():
 
 @register.filter
 def jet_have_admin_static():
-    return VERSION[0] < 3
+    return django.VERSION[0] < 3

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,8 +1,8 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+# from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class TestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()
@@ -11,7 +11,7 @@ class TestModel(models.Model):
         return '%s%d' % (self.field1, self.field2)
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class RelatedToTestModel(models.Model):
     field = models.ForeignKey(TestModel, on_delete=models.CASCADE)
 
@@ -19,7 +19,7 @@ class RelatedToTestModel(models.Model):
         return self.field
 
 
-@python_2_unicode_compatible
+# @python_2_unicode_compatible
 class SearchableTestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,8 +1,10 @@
 from django.db import models
-# from django.utils.encoding import python_2_unicode_compatible
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    python_2_unicode_compatible = None
 
 
-# @python_2_unicode_compatible
 class TestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()
@@ -11,7 +13,6 @@ class TestModel(models.Model):
         return '%s%d' % (self.field1, self.field2)
 
 
-# @python_2_unicode_compatible
 class RelatedToTestModel(models.Model):
     field = models.ForeignKey(TestModel, on_delete=models.CASCADE)
 
@@ -19,7 +20,6 @@ class RelatedToTestModel(models.Model):
         return self.field
 
 
-# @python_2_unicode_compatible
 class SearchableTestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()
@@ -30,3 +30,8 @@ class SearchableTestModel(models.Model):
     @staticmethod
     def autocomplete_search_fields():
         return 'field1'
+
+if python_2_unicode_compatible:
+    TestModel = python_2_unicode_compatible(TestModel)
+    RelatedToTestModel = python_2_unicode_compatible(RelatedToTestModel)
+    SearchableTestModel = python_2_unicode_compatible(SearchableTestModel)

--- a/jet/tests/settings.py
+++ b/jet/tests/settings.py
@@ -60,7 +60,10 @@ DATABASES = {
 }
 
 TIME_ZONE = 'UTC'
-LANGUAGE_CODE = 'en-US'
+if django.VERSION[0] == 3:
+    LANGUAGE_CODE = 'en-us'
+else:
+    LANGUAGE_CODE = 'en-US'
 USE_I18N = True
 USE_L10N = True
 
@@ -71,3 +74,4 @@ STATIC_URL = '/static/'
 
 JET_INDEX_DASHBOARD = 'jet.tests.dashboard.TestIndexDashboard'
 JET_APP_INDEX_DASHBOARD = 'jet.tests.dashboard.TestAppIndexDashboard'
+

--- a/jet/tests/test_filters.py
+++ b/jet/tests/test_filters.py
@@ -43,11 +43,9 @@ class FiltersTestCase(TestCase):
         request = self.factory.get('url', {'field__id__exact': initial.pk})
         field, lookup_params, model, model_admin, field_path = self.get_related_field_ajax_list_filter_params()
         list_filter = RelatedFieldAjaxListFilter(field, request, lookup_params, model, model_admin, field_path)
-
         self.assertTrue(list_filter.has_output())
 
         choices = list_filter.field_choices(field, request, model_admin)
-
         self.assertIsInstance(choices, list)
         self.assertEqual(len(choices), 1)
         self.assertEqual(choices[0], (initial.pk, smart_text(initial)))

--- a/jet/tests/test_tags.py
+++ b/jet/tests/test_tags.py
@@ -1,3 +1,4 @@
+import django
 from django import forms
 try:
     from django.core.urlresolvers import reverse
@@ -5,7 +6,7 @@ except ImportError: # Django 1.11
     from django.urls import reverse
 
 from django.test import TestCase
-from jet.templatetags.jet_tags import jet_select2_lookups, jet_next_object, jet_previous_object
+from jet.templatetags.jet_tags import jet_select2_lookups, jet_next_object, jet_previous_object, jet_have_admin_static
 from jet.tests.models import TestModel, SearchableTestModel
 from django.test.client import RequestFactory
 
@@ -100,3 +101,6 @@ class TagsTestCase(TestCase):
         expected_object = None
 
         self.assertEqual(previous_object, expected_object)
+
+    def test_jet_have_admin_static(self):
+        self.assertEqual(jet_have_admin_static(), django.VERSION[0] < 3)

--- a/jet/tests/test_utils.py
+++ b/jet/tests/test_utils.py
@@ -68,3 +68,7 @@ class UtilsTestCase(TestCase):
         encoder = LazyDateTimeEncoder()
         self.assertEqual(encoder.encode({'key': 1}), '{"key": 1}')
 
+
+    def test_non_json(self):
+        with self.assertRaises(TypeError):
+            JsonResponse([])

--- a/jet/tests/test_views.py
+++ b/jet/tests/test_views.py
@@ -9,6 +9,7 @@ from django.test import TestCase, Client
 from jet.dashboard.modules import LinkList
 from jet.models import Bookmark
 from jet.dashboard.models import UserDashboardModule
+from jet.forms import ModelLookupForm
 
 
 class ViewsTestCase(TestCase):
@@ -227,3 +228,10 @@ class ViewsTestCase(TestCase):
         response = json.loads(response.content.decode())
         self.assertFalse(response['error'])
         self.assertFalse(UserDashboardModule.objects.filter(pk=module.pk).exists())
+
+
+    def test_model_lookup_form(self):
+        response = self.admin.get(reverse('jet:model_lookup'))
+        data = json.loads(response.content.decode())
+        self.assertTrue(data['error'])
+        

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -204,7 +204,6 @@ def get_model_queryset(admin_site, model, request, preserved_filters=None):
         queryset = model_admin.get_queryset(request)
     else:
         queryset = model.objects
-    print(dir(request))
     list_display = model_admin.get_list_display(request)
     list_display_links = model_admin.get_list_display_links(request, list_display)
     list_filter = model_admin.get_list_filter(request)

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -204,7 +204,7 @@ def get_model_queryset(admin_site, model, request, preserved_filters=None):
         queryset = model_admin.get_queryset(request)
     else:
         queryset = model.objects
-
+    print(dir(request))
     list_display = model_admin.get_list_display(request)
     list_display_links = model_admin.get_list_display_links(request, list_display)
     list_filter = model_admin.get_list_filter(request)
@@ -212,7 +212,6 @@ def get_model_queryset(admin_site, model, request, preserved_filters=None):
         if hasattr(model_admin, 'get_search_fields') else model_admin.search_fields
     list_select_related = model_admin.get_list_select_related(request) \
         if hasattr(model_admin, 'get_list_select_related') else model_admin.list_select_related
-
     actions = model_admin.get_actions(request)
     if actions:
         list_display = ['action_checkbox'] + list(list_display)


### PR DESCRIPTION
Removed python_2_unicode_compatible (from source) and admin_static (from templates)