### PR TITLE
fix(django3): django3 compatible

### DIFF
--- a/jet/models.py
+++ b/jet/models.py
@@ -1,8 +1,11 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+try:
+    from django.utils.encoding import python_2_unicode_compatible
+except ImportError:
+    from six import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class Bookmark(models.Model):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 
 def get_install_requires():
-    install_requires = ['Django']
+    install_requires = ['Django', 'six']
 
     try:
         import importlib


### PR DESCRIPTION
When Django3 import python_2_unicode_compatible from six

closes #418