### PR TITLE
Bugfix to add Django 3 compatibility

### DIFF
--- a/docs/dashboard_custom.rst
+++ b/docs/dashboard_custom.rst
@@ -21,7 +21,7 @@ Set Up Custom Dashboard
 
    .. code-block:: python
 
-      from django.utils.translation import ugettext_lazy as _
+      from django.utils.translation import gettext_lazy as _
       from jet.dashboard import modules
       from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/docs/dashboard_modules.rst
+++ b/docs/dashboard_modules.rst
@@ -85,7 +85,7 @@ Usage Example
 -------------
    .. code-block:: python
 
-     from django.utils.translation import ugettext_lazy as _
+     from django.utils.translation import gettext_lazy as _
      from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
      from jet.dashboard.dashboard_modules import google_analytics
 
@@ -137,7 +137,7 @@ Usage Example
 -------------
    .. code-block:: python
 
-     from django.utils.translation import ugettext_lazy as _
+     from django.utils.translation import gettext_lazy as _
      from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
      from jet.dashboard.dashboard_modules import yandex_metrika
 

--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -7,7 +7,7 @@ except ImportError: # Django 1.11
 from django.template.loader import render_to_string
 from jet.dashboard import modules
 from jet.dashboard.models import UserDashboardModule
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.ordered_set import OrderedSet
 from jet.utils import get_admin_site_name, context_to_dict
 
@@ -65,7 +65,7 @@ class Dashboard(object):
 
         .. code-block:: python
 
-            from django.utils.translation import ugettext_lazy as _
+            from django.utils.translation import gettext_lazy as _
             from jet.dashboard import modules
             from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/jet/dashboard/dashboard_modules/google_analytics.py
+++ b/jet/dashboard/dashboard_modules/google_analytics.py
@@ -16,7 +16,7 @@ from googleapiclient.discovery import build
 import httplib2
 from jet.dashboard.modules import DashboardModule
 from oauth2client.client import flow_from_clientsecrets, OAuth2Credentials, AccessTokenRefreshError, Storage
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.utils.encoding import force_text
 

--- a/jet/dashboard/dashboard_modules/google_analytics_views.py
+++ b/jet/dashboard/dashboard_modules/google_analytics_views.py
@@ -12,7 +12,7 @@ from jet.dashboard.models import UserDashboardModule
 from jet.dashboard import dashboard
 from django.http import HttpResponse
 from oauth2client.client import FlowExchangeError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def google_analytics_grant_view(request, pk):

--- a/jet/dashboard/dashboard_modules/yandex_metrika.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika.py
@@ -13,7 +13,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from jet.dashboard.modules import DashboardModule
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.utils.encoding import force_text
 

--- a/jet/dashboard/dashboard_modules/yandex_metrika_views.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika_views.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from jet.dashboard.dashboard_modules.yandex_metrika import YandexMetrikaClient
 from jet.dashboard.models import UserDashboardModule
 from jet.dashboard import dashboard
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def yandex_metrika_grant_view(request, pk):

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -3,7 +3,7 @@ import json
 from six import python_2_unicode_compatible
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
 

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,7 +1,8 @@
 from importlib import import_module
 import json
+from six import python_2_unicode_compatible
+
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 

--- a/jet/dashboard/modules.py
+++ b/jet/dashboard/modules.py
@@ -3,7 +3,7 @@ from django import forms
 from django.contrib.admin.models import LogEntry
 from django.db.models import Q
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import get_app_list, LazyDateTimeEncoder, context_to_dict
 import datetime
 
@@ -177,7 +177,7 @@ class LinkList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -278,7 +278,7 @@ class AppList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -351,7 +351,7 @@ class ModelList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -425,7 +425,7 @@ class RecentActions(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -533,7 +533,7 @@ class Feed(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/jet/dashboard/templates/admin/index.html
+++ b/jet/dashboard/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static jet_dashboard_tags static %}
+{% load i18n jet_dashboard_tags static %}
 
 {% block html %}{% get_dashboard 'index' as dashboard %}{{ block.super }}{% endblock %}
 

--- a/jet/dashboard/views.py
+++ b/jet/dashboard/views.py
@@ -13,7 +13,7 @@ from jet.dashboard.forms import UpdateDashboardModulesForm, AddUserDashboardModu
 from jet.dashboard.models import UserDashboardModule
 from jet.utils import JsonResponse, get_app_list, SuccessMessageMixin, user_is_authenticated
 from django.views.generic import UpdateView
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UpdateDashboardModuleView(SuccessMessageMixin, UpdateView):

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,6 +1,7 @@
+from six import python_2_unicode_compatible
+
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -2,7 +2,7 @@ from six import python_2_unicode_compatible
 
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 @python_2_unicode_compatible

--- a/jet/templates/admin/edit_inline/compact.html
+++ b/jet/templates/admin/edit_inline/compact.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static %}
+{% load i18n admin_urls %}
 
 <div class="inline-group compact" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-prefix="{{ inline_admin_formset.formset.prefix }}" data-inline-verbose-name="{{ inline_admin_formset.opts.verbose_name|capfirst }}" data-inline-delete-text="{% trans "Remove" %}">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>

--- a/jet/templates/rangefilter/date_filter.html
+++ b/jet/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <script>
     function datefilter_apply(event, qs_name, form_name){

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -27,7 +27,7 @@ from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.text import slugify
 
 try:


### PR DESCRIPTION
Add Django 3 support.

(https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis)

Follows the error below that was fixed:
 
```python
$ python manage.py migrate jet
Traceback (most recent call last):
  File "manage.py", line 22, in <module>
    execute_from_command_line(sys.argv)
  File ".../.virtualenvs/supplai-api/lib/python3.6/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File ".../.virtualenvs/supplai-api/lib/python3.6/site-packages/django/core/management/__init__.py", line 377, in execute
    django.setup()
  File ".../.virtualenvs/supplai-api/lib/python3.6/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File ".../.virtualenvs/supplai-api/lib/python3.6/site-packages/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File ".../.virtualenvs/supplai-api/lib/python3.6/site-packages/django/apps/config.py", line 211, in import_models
    self.models_module = import_module(models_module_name)
  File ".../.pyenv/versions/3.6.10/Python.framework/Versions/3.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File ".../lib/python3.6/site-packages/jet/models.py", line 3, in <module>
    from django.utils.encoding import python_2_unicode_compatible
ImportError: cannot import name 'python_2_unicode_compatible'
```