### PR TITLE
explicitly handle django deprecations to satisfy deprecation warnings

### DIFF
--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -1,8 +1,9 @@
 from importlib import import_module
-try:
-    from django.core.urlresolvers import reverse
-except ImportError: # Django 1.11
+import django
+if django.VERSION >= (1, 10):  # https://docs.djangoproject.com/en/dev/releases/1.10/#id3
     from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 
 from django.template.loader import render_to_string
 from jet.dashboard import modules

--- a/jet/dashboard/templatetags/jet_dashboard_tags.py
+++ b/jet/dashboard/templatetags/jet_dashboard_tags.py
@@ -1,9 +1,13 @@
 from __future__ import unicode_literals
+import django
 from django import template
 from jet.dashboard.utils import get_current_dashboard
 
 register = template.Library()
-assignment_tag = register.assignment_tag if hasattr(register, 'assignment_tag') else register.simple_tag
+if django.VERSION >= (1, 9):  # https://docs.djangoproject.com/en/dev/releases/1.9/#assignment-tag
+    assignment_tag = register.simple_tag
+else:
+    assignment_tag = register.assignment_tag()
 
 
 @assignment_tag(takes_context=True)

--- a/jet/dashboard/views.py
+++ b/jet/dashboard/views.py
@@ -1,9 +1,10 @@
+import django
 from django.contrib import messages
 from django.core.exceptions import ValidationError
-try:
-    from django.core.urlresolvers import reverse
-except ImportError: # Django 1.11
+if django.VERSION >= (1, 10):  # https://docs.djangoproject.com/en/dev/releases/1.10/#id3
     from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 
 from django.forms.formsets import formset_factory
 from django.http import HttpResponseRedirect

--- a/jet/ordered_set.py
+++ b/jet/ordered_set.py
@@ -1,7 +1,12 @@
-import collections
+import sys
+
+if sys.version_info > (3, 3):
+    from collections.abc import MutableSet
+else:
+    from collections import MutableSet
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]         # sentinel node for doubly linked list

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 import json
 import os
+import sys
+import django
 from django import template
-try:
-    from django.core.urlresolvers import reverse
-except ImportError: # Django 1.11
+if django.VERSION >= (1, 10):  # https://docs.djangoproject.com/en/dev/releases/1.10/#id3
     from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 
 from django.forms import CheckboxInput, ModelChoiceField, Select, ModelMultipleChoiceField, SelectMultiple
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
@@ -17,14 +19,17 @@ from jet.models import Bookmark
 from jet.utils import get_model_instance_label, get_model_queryset, get_possible_language_codes, \
     get_admin_site, get_menu_items
 
-try:
+if sys.version_info > (3,):
     from urllib.parse import parse_qsl
-except ImportError:
+else:
     from urlparse import parse_qsl
 
 
 register = template.Library()
-assignment_tag = register.assignment_tag if hasattr(register, 'assignment_tag') else register.simple_tag
+if django.VERSION >= (1, 9):  # https://docs.djangoproject.com/en/dev/releases/1.9/#assignment-tag
+    assignment_tag = register.simple_tag
+else:
+    assignment_tag = register.assignment_tag()
 
 
 @assignment_tag

--- a/jet/tests/settings.py
+++ b/jet/tests/settings.py
@@ -7,7 +7,6 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SECRET_KEY = '!DJANGO_JET_TESTS!'
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 DEBUG_PROPAGATE_EXCEPTIONS = True
 
 ROOT_URLCONF = 'jet.tests.urls'
@@ -33,6 +32,7 @@ MIDDLEWARE = MIDDLEWARE_CLASSES = (
 )
 
 if django.VERSION[:2] < (1, 9):
+    TEMPLATE_DEBUG = DEBUG
     TEMPLATE_CONTEXT_PROCESSORS = tuple(global_settings.TEMPLATE_CONTEXT_PROCESSORS) + (
         'django.core.context_processors.request',
     )
@@ -48,7 +48,8 @@ else:
                     'django.template.context_processors.request',
                     'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
-                )
+                ),
+                'debug': DEBUG
             },
         },
     ]

--- a/jet/tests/urls.py
+++ b/jet/tests/urls.py
@@ -5,16 +5,14 @@ from django.contrib import admin
 admin.autodiscover()
 
 
-try:
-    from django.urls import path
-
+if django.VERSION > (1,9):  # https://docs.djangoproject.com/en/dev/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include
     urlpatterns = [
         url(r'^jet/', include('jet.urls', 'jet')),
         url(r'^jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),
         url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-        path('admin/', admin.site.urls),
+        url(r'^admin/', admin.site.urls),
     ]
-except ImportError:  # Django < 2.0
+else:
     urlpatterns = [
         url(r'^jet/', include('jet.urls', 'jet')),
         url(r'^jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import django
 from django.template import Context
 from django.utils import translation
 from jet import settings
@@ -14,10 +15,10 @@ except ImportError:
         pass
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
-try:
-    from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-except ImportError: # Django 1.11
+if django.VERSION >= (1, 10):  # https://docs.djangoproject.com/en/dev/releases/1.10/#id3
     from django.urls import reverse, resolve, NoReverseMatch
+else:
+    from django.core.urlresolvers import reverse, resolve, NoReverseMatch
 
 from django.contrib.admin import AdminSite
 from django.utils.encoding import smart_text


### PR DESCRIPTION
:wave: Hi there,

This PR explicitly handle deprecation warnings in such a way that they are no longer raised when running a project with `python -Wa manage.py runserver`. This is useful for teams that raise these warnings in tests/CI while trying to upgrade their Django version.

Related issue: https://github.com/geex-arts/django-jet/issues/206