### PR TITLE
Fix: disabled url for models where view permission assigned

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Django JET
 |                                                                                                                                   |
 | Developing of new features for Django Jet will be frozen, only critical bugs will be fixed.                                       |
 +-----------------------------------------------------------------------------------------------------------------------------------+
-| `Live Demo <https://github.com/jet-admin/jet-bridge>`_  |
+| `Live Demo <https://github.com/jet-admin/jet-bridge>`_                                                                            |
 +-----------------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Django JET
 |                                                                                                                                   |
 | Developing of new features for Django Jet will be frozen, only critical bugs will be fixed.                                       |
 +-----------------------------------------------------------------------------------------------------------------------------------+
-| `Live Demo <https://app.jetadmin.io/demo?utm_source=jet&utm_medium=banner&utm_campaign=github&utm_content=link&utm_term=promo>`_  |
+| `Live Demo <https://github.com/jet-admin/jet-bridge>`_  |
 +-----------------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -82,7 +82,7 @@ def get_app_list(context, order=True):
                     'perms': perms,
                     'model_name': model._meta.model_name
                 }
-                if perms.get('change', False):
+                if perms.get('change', False) or perms.get('view', False):
                     try:
                         model_dict['admin_url'] = reverse('admin:%s_%s_changelist' % info, current_app=admin_site.name)
                     except NoReverseMatch:


### PR DESCRIPTION
This pull requests fixes the error where users with only view permission were not getting link to the model section.