### PR TITLE
'python_2_unicode_compatible' import fix for Django V3+

### DIFF
--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 
 def get_install_requires():
-    install_requires = ['Django']
+    install_requires = ['Django', 'six']
 
     try:
         import importlib


### PR DESCRIPTION
Since **Django V3,** Django dropped `python_2_unicode_compatible`  from `django.utils.encoding` module.
To be compatible with `Django 3+` we should import that module from `six` package.