### PR TITLE
django.utils.encoding not works so we use six

### DIFF
--- a/jet/models.py
+++ b/jet/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 


### PR DESCRIPTION
django.utils.encoding is default one and not working in Django v3.0 or later vesrions so please check this.