### PR TITLE
Fixed python_2_unicode_compatible import issues

### DIFF
--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 import json
+from six import python_2_unicode_compatible
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
I fixed the python_2_unicode_compatible import from django.utils.encoding module to six module.