### PR TITLE
fix error on django>=3.0 that occurs due to a removing `python_2_unicode_compatible` from the latest versions

### DIFF
--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,10 +1,16 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
+import sys
+
+if sys.version_info.major == 2:
+    from django.utils.encoding import python_2_unicode_compatible
+else:
+    python_2_unicode_compatible = lambda cls: cls
+    
 
 @python_2_unicode_compatible
 class UserDashboardModule(models.Model):

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,9 +1,14 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+import sys
 
+if sys.version_info.major == 2:
+    from django.utils.encoding import python_2_unicode_compatible
+else:
+    python_2_unicode_compatible = lambda cls: cls
 
+    
 @python_2_unicode_compatible
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Environment :: Web Environment',
         'Topic :: Software Development',
         'Topic :: Software Development :: User Interfaces',


### PR DESCRIPTION
`python_2_unicode_compatible` function was removed in django 3.0. This caused the error 

```
ImportError: cannot import name ‘python_2_unicode_compatible’ from ‘django.utils.encoding’
```

in models.py. 

python version == 3.6
django version == 3.2
django-jet == 1.0.8

Now I set the function stub for all version python with major version==3 with a goal avoid the error

