### PR TITLE
django 3 support for 'python_2_unicode_compatible' import error

### DIFF
--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 

--- a/jet/dashboard/templates/admin/index.html
+++ b/jet/dashboard/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static jet_dashboard_tags static %}
+{% load i18n jet_dashboard_tags static %}
 
 {% block html %}{% get_dashboard 'index' as dashboard %}{{ block.super }}{% endblock %}
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/jet/templates/admin/edit_inline/compact.html
+++ b/jet/templates/admin/edit_inline/compact.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static %}
+{% load i18n admin_urls %}
 
 <div class="inline-group compact" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-prefix="{{ inline_admin_formset.formset.prefix }}" data-inline-verbose-name="{{ inline_admin_formset.opts.verbose_name|capfirst }}" data-inline-delete-text="{% trans "Remove" %}">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>

--- a/jet/templates/rangefilter/date_filter.html
+++ b/jet/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <script>
     function datefilter_apply(event, qs_name, form_name){

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
This pull request solves the compatibility problem between the django-jet module and recent versions of django like version 3.x and python 3.x
![image](https://user-images.githubusercontent.com/10107759/135785653-cc456ac4-9686-426b-b9bd-ee803f0da292.png)
