### PR TITLE
Modified the package for importing python_2_unicode_compatible  from django.utils.encoding to six

### DIFF
--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,7 +1,9 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+# from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
+
 from django.utils.translation import ugettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,8 +1,8 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
+from django.utils.translation import ugettext_lazy as _
 
 @python_2_unicode_compatible
 class Bookmark(models.Model):

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "select2": "4.0.0",
     "timepicker": "git://github.com/geex-arts/timepicker",
     "vinyl-buffer": "1.0.0",
-    "vinyl-source-stream": "1.1.0"
+    "vinyl-source-stream": "1.1.0",
+    "six":"1.16.0"
   }
 }


### PR DESCRIPTION
When I was installing the jet pip package, I noticed the error regarding the python_2_unicode_compatible module  and it was as a result of the Django version update where python_2_unicode_compatible is now in six pip package and not django.utils.encoding as the old Django version